### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Order callbacks in the SpectroCoin plugin allow your WordPress site to automatic
 
 ## Changelog
 
-### 1.1.0 ():
+### 1.1.0 (16/07/2025):
 
 _Added_ support for new JSON and old URL-encoded form data callbacks format. New callbacks will be automatically enabled with new SpectroCoin merchant projects created. With old projects, old callback format will be used. In the future versions old callback format will be removed.
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "testspectrocoin/test-drupal-merchant",
+  "name": "spectrocoin/drupal-merchant",
   "description": "SpectroCoin cryptocurrency payment gateway for Drupal",
   "type": "drupal-module",
   "version": "1.1.0",


### PR DESCRIPTION
Added support for new JSON and old URL-encoded form data callbacks format. New callbacks will be automatically enabled with new SpectroCoin merchant projects created. With old projects, old callback format will be used. In the future versions old callback format will be removed.